### PR TITLE
Rewrite bandwidth tool in Python and add histogram stats

### DIFF
--- a/bin/bin/bandwidth
+++ b/bin/bin/bandwidth
@@ -1,69 +1,76 @@
-#!/usr/bin/env bash
-# speedtest-tail.sh
-# Usage:
-#   speedtest-tail.sh [-n N] [DIR]
-# Default DIR: $HOME/data/hosts/$(hostname -s)
-# Requires: gawk (GNU awk)
+#!/usr/bin/env python3
+"""Display recent bandwidth measurements in a tabular format."""
+from __future__ import annotations
 
-set -euo pipefail
+import argparse
+import sys
+from pathlib import Path
 
-N=20
-while getopts ":n:" opt; do
-  case "$opt" in
-    n) N="$OPTARG" ;;
-    *) echo "Usage: $0 [-n N] [DIR]" >&2; exit 2 ;;
-  esac
-done
-shift $((OPTIND-1))
+ROOT = Path(__file__).resolve().parents[2]
+PYTHON_DIR = ROOT / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
 
-DIR="${1:-$HOME/data/hosts/$(hostname -s)}"
+from bandwidth_tool import (  # type: ignore
+    DEFAULT_LIMIT,
+    default_data_directory,
+    limit_measurements,
+    load_measurements,
+    render_stats,
+    render_table,
+)
 
-u="$DIR/speedtest-upload"
-d="$DIR/speedtest-download"
-p="$DIR/speedtest-ping"
-s="$DIR/speedtest-ssid"
 
-# Sanity check
-for f in "$u" "$d" "$p" "$s"; do
-  [[ -f "$f" ]] || { echo "Missing file: $f" >&2; exit 1; }
-done
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-n",
+        dest="limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="Number of rows to display",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Display histograms instead of a table",
+    )
+    parser.add_argument(
+        "--text",
+        action="store_true",
+        help="Render histograms using textual output",
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        type=Path,
+        default=default_data_directory(),
+        help="Directory containing speedtest data files",
+    )
+    return parser.parse_args(argv)
 
-gawk -v n="$N" '
-BEGIN {
-  FS=" ";
-}
-# For each file, store value by timestamp.
-# Value may contain spaces (SSID), so reconstruct from $2..end.
-FNR > 0 {
-  ts = $1
-  $1 = ""
-  val = substr($0,2)  # leading space removed
-  key[ts] = 1
 
-  fn = FILENAME
-  if (fn ~ /speedtest-upload$/)   up[ts]   = val
-  else if (fn ~ /speedtest-download$/) down[ts] = val
-  else if (fn ~ /speedtest-ping$/)     ping[ts] = val
-  else if (fn ~ /speedtest-ssid$/)     ssid[ts] = val
-}
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        measurements = load_measurements(args.directory)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive exit path
+        print(exc, file=sys.stderr)
+        return 1
 
-END {
-  # Sort timestamps numerically ascending
-  count = asorti(key, idx, "@ind_num_asc")
-  start = count - n + 1
-  if (start < 1) start = 1
+    limited = limit_measurements(measurements, args.limit)
+    if args.stats:
+        try:
+            result = render_stats(limited, text=args.text)
+        except RuntimeError as exc:
+            print(exc, file=sys.stderr)
+            return 1
+        if result is not None:
+            print(result)
+    else:
+        print(render_table(limited))
+    return 0
 
-  # Header
-  printf "%s|%s|%s|%s|%s\n", "datetime", "upload MiBps", "download MiBps", "ping ms", "ssid"
 
-  for (i = start; i <= count; i++) {
-    ts = idx[i]
-    dt = strftime("%Y-%m-%d %H:%M:%S", ts)  # local time
-    u  = (ts in up)   ? up[ts]   : "-"
-    d  = (ts in down) ? down[ts] : "-"
-    pg = (ts in ping) ? ping[ts] : "-"
-    ss = (ts in ssid) ? ssid[ts] : "-"
-    printf "%s  |%11.2f|%13.2f|%6.2f|%s\n", dt, u, d, pg, ss
-  }
-}
-' "$u" "$d" "$p" "$s" | column -t -s '|'
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/python/bandwidth_tool/__init__.py
+++ b/python/bandwidth_tool/__init__.py
@@ -1,0 +1,304 @@
+"""Utilities for inspecting recorded bandwidth measurements."""
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence
+
+from .tabular import format_table
+
+DEFAULT_LIMIT = 20
+
+UPLOAD_FILE = "speedtest-upload"
+DOWNLOAD_FILE = "speedtest-download"
+PING_FILE = "speedtest-ping"
+SSID_FILE = "speedtest-ssid"
+
+
+@dataclass
+class Measurement:
+    """Represents a single measurement row."""
+
+    timestamp: int
+    upload: Optional[float] = None
+    download: Optional[float] = None
+    ping: Optional[float] = None
+    ssid: Optional[str] = None
+
+    def as_row(self) -> Sequence[str]:
+        dt = datetime.fromtimestamp(self.timestamp).strftime("%Y-%m-%d %H:%M:%S")
+        return (
+            dt,
+            format_number(self.upload),
+            format_number(self.download),
+            format_number(self.ping),
+            self.ssid if self.ssid is not None and self.ssid != "" else "-",
+        )
+
+
+def format_number(value: Optional[float]) -> str:
+    if value is None:
+        return "-"
+    return f"{value:0.2f}"
+
+
+def default_data_directory() -> Path:
+    hostname = socket.gethostname().split(".")[0]
+    return Path.home() / "data" / "hosts" / hostname
+
+
+def _ensure_files(directory: Path) -> Mapping[str, Path]:
+    paths = {
+        "upload": directory / UPLOAD_FILE,
+        "download": directory / DOWNLOAD_FILE,
+        "ping": directory / PING_FILE,
+        "ssid": directory / SSID_FILE,
+    }
+    missing = [str(path) for path in paths.values() if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(f"Missing file(s): {', '.join(missing)}")
+    return paths
+
+
+def _parse_numeric_file(path: Path) -> Dict[int, float]:
+    data: Dict[int, float] = {}
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            timestamp_str, _, value_str = line.partition(" ")
+            if not value_str:
+                continue
+            timestamp = int(timestamp_str)
+            value = float(value_str.strip())
+            data[timestamp] = value
+    return data
+
+
+def _parse_text_file(path: Path) -> Dict[int, str]:
+    data: Dict[int, str] = {}
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.rstrip("\n")
+            if not line:
+                continue
+            timestamp_str, _, value = line.partition(" ")
+            timestamp = int(timestamp_str)
+            data[timestamp] = value.lstrip()
+    return data
+
+
+def load_measurements(directory: Path) -> List[Measurement]:
+    paths = _ensure_files(directory)
+    uploads = _parse_numeric_file(paths["upload"])
+    downloads = _parse_numeric_file(paths["download"])
+    pings = _parse_numeric_file(paths["ping"])
+    ssids = _parse_text_file(paths["ssid"])
+
+    timestamps = sorted({*uploads.keys(), *downloads.keys(), *pings.keys(), *ssids.keys()})
+    measurements: List[Measurement] = []
+    for ts in timestamps:
+        measurements.append(
+            Measurement(
+                timestamp=ts,
+                upload=uploads.get(ts),
+                download=downloads.get(ts),
+                ping=pings.get(ts),
+                ssid=ssids.get(ts),
+            )
+        )
+    return measurements
+
+
+def limit_measurements(measurements: Sequence[Measurement], limit: int) -> List[Measurement]:
+    if limit <= 0:
+        return []
+    return list(measurements[-limit:])
+
+
+def render_table(measurements: Iterable[Measurement]) -> str:
+    rows = [measurement.as_row() for measurement in measurements]
+    headers = ("datetime", "upload MiBps", "download MiBps", "ping ms", "ssid")
+    return format_table(headers, rows, colalign=("left", "right", "right", "right", "left"))
+
+
+def _collect_values(measurements: Iterable[Measurement], attribute: str) -> List[float]:
+    values: List[float] = []
+    for measurement in measurements:
+        value = getattr(measurement, attribute)
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _determine_edges(values: Sequence[float], bins: int = 10) -> List[float]:
+    if not values:
+        return [0.0, 1.0]
+    minimum = min(values)
+    maximum = max(values)
+    if minimum == maximum:
+        width = max(abs(minimum) * 0.1, 1.0)
+        return [minimum - width, minimum + width]
+    bins = max(1, bins)
+    step = (maximum - minimum) / bins
+    edges = [minimum + step * i for i in range(bins)]
+    edges.append(maximum)
+    edges[0] = minimum
+    edges[-1] = maximum
+    return edges
+
+
+def _histogram_from_edges(values: Sequence[float], edges: Sequence[float]) -> List[int]:
+    counts = [0 for _ in range(len(edges) - 1)]
+    if not values:
+        return counts
+    for value in values:
+        if value <= edges[0]:
+            index = 0
+        elif value >= edges[-1]:
+            index = len(counts) - 1
+        else:
+            for idx in range(len(edges) - 1):
+                if edges[idx] <= value < edges[idx + 1]:
+                    index = idx
+                    break
+            else:  # pragma: no cover - defensive programming
+                index = len(counts) - 1
+        counts[index] += 1
+    return counts
+
+
+def _bin_centers(edges: Sequence[float]) -> List[float]:
+    return [(edges[i] + edges[i + 1]) / 2 for i in range(len(edges) - 1)]
+
+
+def _format_range(start: float, end: float, is_last: bool) -> str:
+    right = "]" if is_last else ")"
+    return f"[{start:7.2f}, {end:7.2f}{right}"
+
+
+def _bar(count: int, max_count: int, width: int, *, reverse: bool = False) -> str:
+    if max_count <= 0 or count <= 0:
+        bar = ""
+    else:
+        scaled = max(1, round(count / max_count * width))
+        bar = "█" * min(width, scaled)
+    if reverse:
+        return bar.rjust(width)
+    return bar.ljust(width)
+
+
+def _render_violin_text(edges: Sequence[float], upload_counts: Sequence[int], download_counts: Sequence[int]) -> List[str]:
+    width = 16
+    lines = ["Upload/Download speeds (MiBps)"]
+    lines.append("upload".rjust(width) + " │ " + "download".ljust(width))
+    max_count = max([*upload_counts, *download_counts, 0])
+    for idx, (start, end) in enumerate(zip(edges[:-1], edges[1:])):
+        label = _format_range(start, end, idx == len(edges) - 2)
+        label = label.ljust(23)
+        left = _bar(upload_counts[idx], max_count, width, reverse=True)
+        right = _bar(download_counts[idx], max_count, width)
+        lines.append(f"{label} {left}│{right}")
+    return lines
+
+
+def _render_ping_text(edges: Sequence[float], counts: Sequence[int]) -> List[str]:
+    width = 32
+    lines = ["Ping times (ms)"]
+    max_count = max([*counts, 0])
+    for idx, (start, end) in enumerate(zip(edges[:-1], edges[1:])):
+        label = _format_range(start, end, idx == len(edges) - 2)
+        label = label.ljust(23)
+        bar = _bar(counts[idx], max_count, width)
+        lines.append(f"{label} {bar}")
+    return lines
+
+
+def render_stats_text(measurements: Sequence[Measurement], bins: int = 10) -> str:
+    uploads = _collect_values(measurements, "upload")
+    downloads = _collect_values(measurements, "download")
+    pings = _collect_values(measurements, "ping")
+
+    lines: List[str] = []
+
+    if uploads or downloads:
+        edges = _determine_edges([*uploads, *downloads], bins=bins)
+        upload_counts = _histogram_from_edges(uploads, edges)
+        download_counts = _histogram_from_edges(downloads, edges)
+        lines.extend(_render_violin_text(edges, upload_counts, download_counts))
+    else:
+        lines.append("No upload/download data available.")
+
+    lines.append("")
+
+    if pings:
+        ping_edges = _determine_edges(pings, bins=bins)
+        ping_counts = _histogram_from_edges(pings, ping_edges)
+        lines.extend(_render_ping_text(ping_edges, ping_counts))
+    else:
+        lines.append("No ping data available.")
+
+    return "\n".join(lines)
+
+
+def render_stats_graphical(measurements: Sequence[Measurement], bins: int = 10) -> None:
+    try:
+        import matplotlib.pyplot as plt  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depends on optional dependency
+        raise RuntimeError("Matplotlib is required for graphical statistics") from exc
+
+    uploads = _collect_values(measurements, "upload")
+    downloads = _collect_values(measurements, "download")
+    pings = _collect_values(measurements, "ping")
+
+    fig, (ax_speed, ax_ping) = plt.subplots(2, 1, figsize=(8, 8))
+
+    edges = _determine_edges([*uploads, *downloads], bins=bins)
+    upload_counts = _histogram_from_edges(uploads, edges)
+    download_counts = _histogram_from_edges(downloads, edges)
+    centers = _bin_centers(edges)
+    heights = [edges[i + 1] - edges[i] for i in range(len(edges) - 1)]
+
+    ax_speed.barh(centers, upload_counts, height=heights, align="center", color="tab:blue", label="Upload")
+    ax_speed.barh(centers, [-count for count in download_counts], height=heights, align="center", color="tab:orange", label="Download")
+    ax_speed.axvline(0, color="black", linewidth=0.8)
+    ax_speed.set_xlabel("Sample count")
+    ax_speed.set_ylabel("MiBps")
+    ax_speed.set_title("Upload/Download distribution")
+    ax_speed.legend()
+
+    ping_edges = _determine_edges(pings, bins=bins)
+    ping_counts = _histogram_from_edges(pings, ping_edges)
+    ping_centers = _bin_centers(ping_edges)
+    widths = [ping_edges[i + 1] - ping_edges[i] for i in range(len(ping_edges) - 1)]
+
+    ax_ping.bar(ping_centers, ping_counts, width=widths, color="tab:green")
+    ax_ping.set_xlabel("Ping (ms)")
+    ax_ping.set_ylabel("Sample count")
+    ax_ping.set_title("Ping distribution")
+
+    plt.tight_layout()
+    plt.show()
+
+
+def render_stats(measurements: Sequence[Measurement], *, text: bool, bins: int = 10) -> Optional[str]:
+    if text:
+        return render_stats_text(measurements, bins=bins)
+    render_stats_graphical(measurements, bins=bins)
+    return None
+
+
+__all__ = [
+    "DEFAULT_LIMIT",
+    "Measurement",
+    "default_data_directory",
+    "limit_measurements",
+    "load_measurements",
+    "render_stats",
+    "render_stats_graphical",
+    "render_stats_text",
+    "render_table",
+]

--- a/python/bandwidth_tool/tabular.py
+++ b/python/bandwidth_tool/tabular.py
@@ -1,0 +1,67 @@
+"""Minimal tabular rendering helpers used by CLI tools.
+
+This module provides a lightweight alternative to third-party table
+renderers so the repository does not depend on external packages at run
+or test time.  The :func:`format_table` helper aligns text in a way that is
+compatible with traditional command line utilities such as ``column``.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence
+
+Alignment = Sequence[str]
+Row = Sequence[str]
+
+
+def _align_cell(text: str, width: int, align: str) -> str:
+    if align == "right":
+        return text.rjust(width)
+    if align == "center":
+        return text.center(width)
+    # Default to left alignment
+    return text.ljust(width)
+
+
+def format_table(headers: Sequence[str], rows: Iterable[Row], *, colalign: Alignment | None = None) -> str:
+    """Return a string representing a table with aligned columns.
+
+    Parameters
+    ----------
+    headers:
+        An iterable of column headers.
+    rows:
+        An iterable containing row sequences.  Each value is expected to be a
+        string that is already formatted for display.
+    colalign:
+        Optional iterable describing the alignment for each column.  Valid
+        values are ``"left"``, ``"right"`` and ``"center"``.  When omitted, the
+        header alignment defaults to left alignment.
+    """
+
+    row_list: List[Row] = [tuple(row) for row in rows]
+    num_cols = len(headers)
+
+    if colalign is None:
+        colalign = tuple("left" for _ in range(num_cols))
+    elif len(colalign) != num_cols:
+        raise ValueError("column alignment must match number of headers")
+
+    widths = [len(headers[i]) for i in range(num_cols)]
+    for row in row_list:
+        if len(row) != num_cols:
+            raise ValueError("row has different number of columns than headers")
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    header_line = "  ".join(
+        _align_cell(headers[i], widths[i], colalign[i]) for i in range(num_cols)
+    )
+    divider = "  ".join("-" * widths[i] for i in range(num_cols))
+
+    body_lines = [
+        "  ".join(_align_cell(cell, widths[i], colalign[i]) for i, cell in enumerate(row))
+        for row in row_list
+    ]
+
+    lines = [header_line, divider, *body_lines]
+    return "\n".join(lines)

--- a/tests/test_bandwidth.py
+++ b/tests/test_bandwidth.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+# Make the repository's python utilities importable when tests execute directly.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_DIR = PROJECT_ROOT / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+from bandwidth_tool import (
+    limit_measurements,
+    load_measurements,
+    render_stats,
+    render_stats_text,
+    render_table,
+)
+
+
+@pytest.fixture()
+def sample_data(tmp_path: Path) -> Path:
+    timestamps = [1_700_000_000, 1_700_000_600, 1_700_001_200]
+    uploads = [100.0, 110.0, 120.0]
+    downloads = [200.0, 210.0, 220.0]
+    pings = [10.0, 11.0, 12.0]
+    ssids = ["Office WiFi", "Office WiFi", "Guest Network"]
+
+    def write_file(name: str, values: list[str]) -> None:
+        path = tmp_path / name
+        path.write_text("\n".join(values) + "\n", encoding="utf-8")
+
+    write_file("speedtest-upload", [f"{ts} {value}" for ts, value in zip(timestamps, uploads)])
+    write_file("speedtest-download", [f"{ts} {value}" for ts, value in zip(timestamps, downloads)])
+    write_file("speedtest-ping", [f"{ts} {value}" for ts, value in zip(timestamps, pings)])
+    write_file("speedtest-ssid", [f"{ts} {ssid}" for ts, ssid in zip(timestamps, ssids)])
+    return tmp_path
+
+
+def test_render_table_with_limit(sample_data: Path) -> None:
+    measurements = load_measurements(sample_data)
+    limited = limit_measurements(measurements, 2)
+    table = render_table(limited)
+
+    lines = table.splitlines()
+    assert lines[0].startswith("datetime")
+    # Ensure we only rendered the most recent two timestamps.
+    expected_dates = [
+        datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+        for ts in (1_700_000_600, 1_700_001_200)
+    ]
+    actual_dates = [line[:19] for line in lines[2:]]
+    assert actual_dates == expected_dates
+    # Numbers should be formatted with two decimals.
+    body_lines = lines[2:]
+    assert any("210.00" in line for line in body_lines)
+    assert any("12.00" in line for line in body_lines)
+
+
+def test_cli_outputs_table(sample_data: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PYTHON_DIR)
+    script = PROJECT_ROOT / "bin" / "bin" / "bandwidth"
+    result = subprocess.run(
+        [str(script), "-n", "1", str(sample_data)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "datetime" in result.stdout.splitlines()[0]
+    assert "Guest" in result.stdout
+
+
+def test_cli_missing_file_error(tmp_path: Path) -> None:
+    # Only create a subset of the required files.
+    (tmp_path / "speedtest-upload").write_text("1700000000 10.0\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PYTHON_DIR)
+    script = PROJECT_ROOT / "bin" / "bin" / "bandwidth"
+    result = subprocess.run(
+        [str(script), str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "Missing file" in result.stderr
+
+
+def test_render_stats_text(sample_data: Path) -> None:
+    measurements = load_measurements(sample_data)
+    limited = limit_measurements(measurements, 3)
+    stats_output = render_stats_text(limited)
+    assert "Upload/Download speeds" in stats_output
+    assert "Ping times" in stats_output
+
+
+def test_cli_stats_text(sample_data: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PYTHON_DIR)
+    script = PROJECT_ROOT / "bin" / "bin" / "bandwidth"
+    result = subprocess.run(
+        [str(script), "--stats", "--text", "-n", "2", str(sample_data)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "Upload/Download speeds" in result.stdout
+    assert "Ping times" in result.stdout
+
+
+def test_render_stats_requires_matplotlib(sample_data: Path) -> None:
+    measurements = load_measurements(sample_data)
+    limited = limit_measurements(measurements, 1)
+    with pytest.raises(RuntimeError):
+        render_stats(limited, text=False)


### PR DESCRIPTION
## Summary
- rewrite the legacy bandwidth shell script as a Python CLI with argparse and tabular output
- add unit and CLI tests that exercise the new implementation and failure paths
- introduce a --stats mode with text or graphical histogram output for upload/download and ping data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e177c9d8708328a057ba7f55d13e5d