### PR TITLE
Configure Markdown files to use markdown-mode

### DIFF
--- a/emacs/elisp/emacs.el
+++ b/emacs/elisp/emacs.el
@@ -53,6 +53,7 @@ Return non-nil when the load succeeds."
     ein	         ;; cf. https://github.com/millejoh/emacs-ipython-notebook
     importmagic  ;; For use with elpy.
     flycheck	 ;; Notably, instead of flymake.
+    markdown-mode ;; Requires an external Markdown renderer such as pandoc (not installed here).
     magit        ;; git support.
     math-preview ;; For use with ein.  https://gitlab.com/matsievskiysv/math-preview
     python-isort ;; For use with elpy.

--- a/emacs/elisp/mode-hooks.el
+++ b/emacs/elisp/mode-hooks.el
@@ -8,6 +8,7 @@
 ;; I usually want my .h files in C++ mode.
 (add-to-list 'auto-mode-alist '("\\.h\\'" . c++-mode))
 (add-to-list 'auto-mode-alist '("\\.html\\'" . web-mode))
+(add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
 (add-to-list 'auto-mode-alist '("mutt-[a-z0-9]+-[0-9]+-[0-9]+-[0-9]+" . post-mode))
 ;; YAML mode
 ;; https://raw.githubusercontent.com/yoshiki/yaml-mode/master/yaml-mode.el


### PR DESCRIPTION
## Summary
- ensure `markdown-mode` is installed via the Emacs package list with a note about requiring a Markdown renderer such as pandoc
- associate `.md` files with `markdown-mode` so Markdown files open in the correct major mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593d2584e08328ab0fd7d0929d6ad1)